### PR TITLE
K8SPXC-1008: PXC domain detection

### DIFF
--- a/cmd/peer-list/main.go
+++ b/cmd/peer-list/main.go
@@ -89,10 +89,14 @@ func main() {
 		ns = os.Getenv("POD_NAMESPACE")
 	}
 	log.Printf("Peer finder enter")
-	var domainName string
 
-	// If domain is not provided, try to get it from resolv.conf
-	if *domain == "" {
+	// If domain is not provided, try to get it from environment variables OR from resolv.conf.
+	domainName := *namespace
+	if domainName == "" {
+		domainName = os.Getenv("PXC_DOMAIN")
+	}
+
+	if domainName == "" {
 		resolvConfBytes, err := ioutil.ReadFile("/etc/resolv.conf")
 		resolvConf := string(resolvConfBytes)
 		if err != nil {


### PR DESCRIPTION
Allows to use the environment variable PXC_DOMAIN to define the domain since the '-domain' parameter is not used anywhere.